### PR TITLE
Support double quoted string in python3 arguments

### DIFF
--- a/mimic-cross.deno/src/python.ts
+++ b/mimic-cross.deno/src/python.ts
@@ -78,7 +78,7 @@ export function callMimicedPython(
     `${config.internalBin}/bash`,
     "-c",
     `exec -a ${calledAs} -- ${config.hostRoot}/usr/bin/${versionedPython} "${
-      args.join('" "')
+      args.map(arg => arg.replaceAll('"', '\\"')).join('" "')
     }"`,
   ])
     .env({


### PR DESCRIPTION
Temporary fix for `colcon build` error due to it runs `python3` command with arguments include `"`