### PR TITLE
KeepOriginalBin use original path

### DIFF
--- a/mimic-cross.deno/apt/apt.ts
+++ b/mimic-cross.deno/apt/apt.ts
@@ -110,7 +110,7 @@ export async function aptGet(arg: string | string[]) {
   const ts = format(new Date(), "yyyy-MM-dd HH:mm:ss");
   const args = arg instanceof Array ? arg : $.split(arg);
   logger.info(`(aptGet) Run apt-get ${arg}`);
-  await $.command([`${config.keepBin}/apt-get`, ...args]).env(
+  await $.command([`${config.keep}/usr/bin/apt-get`, ...args]).env(
     Deno.env.toObject(),
   );
   if (Deno.env.get("MIMIC_CROSS_DISABLE") === "1") {

--- a/mimic-cross.deno/config/config.ts
+++ b/mimic-cross.deno/config/config.ts
@@ -7,8 +7,7 @@ export let config = {
   mimicCrossRoot: "/mimic-cross/mimic-cross.deno",
   internalRoot: "/mimic-cross/mimic-cross/internal",
   internalBin: "/mimic-cross/mimic-cross/internal/bin",
-  keepBin: "/mimic-cross/mimic-cross/keep/bin",
-  keepHostBin: "/mimic-cross/mimic-cross_bin",
+  keep: "/mimic-cross/mimic-cross/keep",
   logFile: "/var/log/mimic-cross.log",
   logMode: "default", // default | verbose | debug
 };

--- a/mimic-cross.deno/src/args.ts
+++ b/mimic-cross.deno/src/args.ts
@@ -2,16 +2,14 @@ import $ from "daxex/mod.ts";
 import { PathRefLike } from "daxex/mod.ts";
 import { config } from "../config/config.ts";
 import { logger } from "./log.ts";
+import { keepOriginalBin } from "./deploy.ts";
 
 export async function createGccTrampoline(targetPath: PathRefLike) {
   logger.info(`(createGccTrampoline) Create gcc trampoline for ${targetPath}`);
-  const tmpDir = await Deno.makeTempDir();
   const targetPathRef = $.path(targetPath);
-  const keepedPathRef = $.path(config.keepHostBin).join(
-    targetPathRef.basename(),
-  );
   const hostPathRef = $.path(`${config.hostRoot}/${targetPath}`);
-  await hostPathRef.rename(keepedPathRef);
+  const keepedPathRef = await keepOriginalBin(hostPathRef);
+  const tmpDir = await Deno.makeTempDir();
   await $`${config.internalBin}/zig build --build-file build_gcc.zig -Dmimic_target=${keepedPathRef} -Dmimic_arch=${config.arch} -Doptimize=ReleaseSmall -p ${tmpDir} --cache-dir ${tmpDir}/cache`
     .cwd(config.mimicCrossRoot + "/mimic-arg.zig");
   await $.path(`${tmpDir}/bin/${targetPathRef.basename()}`).rename(hostPathRef);

--- a/mimic-cross.deno/src/deploy.ts
+++ b/mimic-cross.deno/src/deploy.ts
@@ -6,9 +6,11 @@ import { isElfExecutable, isInPath, parseLdconf } from "./util.ts";
 
 export async function keepOriginalBin(path: PathRefLike) {
   const pathRef = $.path(path);
-  const dst = $.path(`${config.keepBin}/${pathRef.basename()}`);
-  await pathRef.copyFile(dst);
-  logger.info(`(keepOriginalBin) Copy ${path} to ${dst}`);
+  const dst = $.path(`${config.keep}/${pathRef}`);
+  await dst.parent()?.ensureDir();
+  await pathRef.rename(dst);
+  logger.info(`(keepOriginalBin) Move ${path} to ${dst}`);
+  return dst;
 }
 
 export async function readRunpath(

--- a/mimic-cross.deno/src/python.ts
+++ b/mimic-cross.deno/src/python.ts
@@ -22,7 +22,7 @@ export function callNativePython(
     `${config.internalBin}/qemu-${config.arch}`,
     "-0",
     `${calledAs}`,
-    `${config.keepBin}/${versionedPython}`,
+    `${config.keep}/usr/bin/${versionedPython}`,
     "--",
     ...args,
   ]).env({ ...Deno.env.toObject(), "MIMIC_CROSS_DISABLE": "1" });

--- a/mimic-cross.deno/src/setup.ts
+++ b/mimic-cross.deno/src/setup.ts
@@ -12,18 +12,12 @@ export async function setup() {
   ]);
   await runOnHost("chmod 666 /dev/random /dev/urandom /dev/null /dev/zero");
   await $.path(`${config.logFile}`).parent()?.mkdir({ recursive: true });
-  await $.path(`${config.keepBin}`).mkdir({ recursive: true });
+  await $.path(`${config.keep}`).mkdir({ recursive: true });
   await $.path(`${config.internalBin}`).mkdir({ recursive: true });
   await $.path(`${config.internalRoot}/arch`).writeText(config.arch);
   await $.path(`/usr/${config.arch}-linux-gnu`).createSymlinkTo(
     `${config.hostRoot}/usr/${config.arch}-linux-gnu`,
   );
-  await $.path(`${config.hostRoot}`).join(`${config.keepHostBin}`).parent()
-    ?.mkdir({ recursive: true });
-  await $.path(`${config.hostRoot}/${config.keepHostBin}`).createSymlinkTo(
-    `../${$.path(config.keepHostBin).basename()}`,
-  );
-  await $.path(config.keepHostBin).mkdir({ recursive: true });
   await aptGetOnHost(["update"]);
   await deployInstalledPackages();
   await aptGetOnHost(["clean"]);


### PR DESCRIPTION
KeepOriginalBin is now easier to use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated internal path configurations to streamline and improve the reliability of software deployment processes.
- **Chores**
	- Removed obsolete configuration declarations to enhance clarity and maintainability of the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->