### PR TITLE
Fix python script with argument -m

### DIFF
--- a/mimic-cross.deno/src/python.ts
+++ b/mimic-cross.deno/src/python.ts
@@ -89,14 +89,8 @@ export function callMimicedPython(
 }
 
 function detectModule(args: string[]): string | undefined {
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "-m") {
-      if (i + 1 >= args.length) {
-        throw new Error("Can't find module name after -m option.");
-      }
-      return args[i + 1];
-    }
-  }
+  // FXIME
+  if (args[0] === "-m") return args[1];
   return undefined;
 }
 


### PR DESCRIPTION
I was failing with cases like `python3 foo.py -m`. Temporarily, -m is assumed to always come as the first argument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved module detection logic with a more efficient conditional check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->